### PR TITLE
Update specially prepared build-release workflow to trigger on version tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,8 +3,9 @@
 name: Build release assets
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -42,9 +43,7 @@ jobs:
       - name: Build Python distributions
         run: uv build
 
-      - name: Upload distributions to release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
             files: dist/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Modify the workflow to trigger on pushes of version tags instead of release creation.